### PR TITLE
Feat/auth resolve #22 and fix critical bug

### DIFF
--- a/src/main/java/io/github/teamwaff1e/waffle/domain/auth/controller/AuthController.java
+++ b/src/main/java/io/github/teamwaff1e/waffle/domain/auth/controller/AuthController.java
@@ -29,32 +29,32 @@ public class AuthController {
 
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
-    public void signUp(@RequestBody SignupRequestDto signupRequestDto) {
+    public void signUp(@Validated @RequestBody SignupRequestDto signupRequestDto) {
         authService.signUp(signupRequestDto);
     }
 
     @PostMapping("/signup/nickname")
     @ResponseStatus(HttpStatus.OK)
-    public void validateNickname(@RequestBody ValidateNicknameRequestDto validateNicknameRequestDto) {
+    public void validateNickname(@Validated @RequestBody ValidateNicknameRequestDto validateNicknameRequestDto) {
         authService.validateNickname(validateNicknameRequestDto.getNickname());
     }
 
     @PostMapping("/signup/email")
     @ResponseStatus(HttpStatus.OK)
-    public void validateEmail(@RequestBody ValidateEmailRequestDto validateEmailRequestDto) {
+    public void validateEmail(@Validated @RequestBody ValidateEmailRequestDto validateEmailRequestDto) {
         authService.validateEmail(validateEmailRequestDto.getEmail());
 
     }
 
     @PostMapping("/login")
     @ResponseStatus(HttpStatus.OK)
-    public void login(HttpServletRequest request, @Validated @RequestBody LoginRequestDto loginRequestDto,
-                      @Login AuthVo loginAuthVo) {
+    public void login(@Login(allowUnauthenticated = true) AuthVo loginAuthVo, HttpServletRequest request,
+                      @Validated @RequestBody LoginRequestDto loginRequestDto) {
 
         // todo: decrypt password
 
-        if (loginAuthVo != null) {
-            return; // todo: return null or throw exception
+        if (loginAuthVo.isAuthenticated()) {
+            throw new IllegalStateException(); // todo
         }
 
         AuthVo authVo = authService.login(loginRequestDto);

--- a/src/main/java/io/github/teamwaff1e/waffle/domain/auth/service/AuthService.java
+++ b/src/main/java/io/github/teamwaff1e/waffle/domain/auth/service/AuthService.java
@@ -51,6 +51,6 @@ public class AuthService {
         Member member = authRepository.findValidMember(loginRequestDto.getEmail(), loginRequestDto.getPwd())
                 .orElseThrow(LoginFailureException::new);
 
-        return new AuthVo(member.getId());
+        return AuthVo.from(member.getId());
     }
 }

--- a/src/main/java/io/github/teamwaff1e/waffle/domain/auth/vo/AuthVo.java
+++ b/src/main/java/io/github/teamwaff1e/waffle/domain/auth/vo/AuthVo.java
@@ -1,14 +1,23 @@
 package io.github.teamwaff1e.waffle.domain.auth.vo;
 
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class AuthVo {
 
     private final Long memberId;
+    private final boolean authenticated;
 
+    public static AuthVo from(long memberId) {
+        return new AuthVo(memberId, true);
+    }
+
+    public static AuthVo newUnauthenticatedInstance() {
+        return new AuthVo(null, false);
+    }
 }

--- a/src/main/java/io/github/teamwaff1e/waffle/domain/comment/controller/CommentController.java
+++ b/src/main/java/io/github/teamwaff1e/waffle/domain/comment/controller/CommentController.java
@@ -61,6 +61,6 @@ public class CommentController {
                               @PathVariable @NotNull @Positive Long waffleId,
                               @PathVariable @NotNull @Positive Long commentId) {
 
-        commentService.deleteComment(waffleId, commentId);
+        commentService.deleteComment(authVo, waffleId, commentId);
     }
 }

--- a/src/main/java/io/github/teamwaff1e/waffle/domain/comment/controller/CommentController.java
+++ b/src/main/java/io/github/teamwaff1e/waffle/domain/comment/controller/CommentController.java
@@ -57,8 +57,10 @@ public class CommentController {
 
     @DeleteMapping("/{commentId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteComment(@PathVariable @NotNull @Positive Long waffleId,
+    public void deleteComment(@Login AuthVo authVo,
+                              @PathVariable @NotNull @Positive Long waffleId,
                               @PathVariable @NotNull @Positive Long commentId) {
+
         commentService.deleteComment(waffleId, commentId);
     }
 }

--- a/src/main/java/io/github/teamwaff1e/waffle/domain/comment/service/CommentService.java
+++ b/src/main/java/io/github/teamwaff1e/waffle/domain/comment/service/CommentService.java
@@ -67,7 +67,16 @@ public class CommentService {
         return converter.convert(updatedComment);
     }
 
-    public void deleteComment(Long waffleId, Long commentId) {
+    public void deleteComment(AuthVo authVo, Long waffleId, Long commentId) {
+
+        Comment comment = commentRepository.find(waffleId, commentId);
+        Member commentMember = comment.getMember();
+        Member loginMember = memberRepository.find(authVo.getMemberId());
+
+        if (loginMember != commentMember) {
+            throw new UnauthorizedException(); // todo: error message
+        }
+
         commentRepository.delete(waffleId, commentId);
         waffleRepository.decreaseCommentCount(waffleId);
     }

--- a/src/main/java/io/github/teamwaff1e/waffle/global/annotation/Login.java
+++ b/src/main/java/io/github/teamwaff1e/waffle/global/annotation/Login.java
@@ -5,7 +5,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * @Login AuthVo authVo: authVo.isAuthenticated() == true
+ * @Login(allowUnauthenticated = true) AuthVo authVo: authVo.isAuthenticated() can be either true or false
+ */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Login {
+    boolean allowUnauthenticated() default false;
 }

--- a/src/main/java/io/github/teamwaff1e/waffle/global/argumentresolver/LoginAuthVoArgumentResolver.java
+++ b/src/main/java/io/github/teamwaff1e/waffle/global/argumentresolver/LoginAuthVoArgumentResolver.java
@@ -29,10 +29,22 @@ public class LoginAuthVoArgumentResolver implements HandlerMethodArgumentResolve
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         HttpSession session = request.getSession(false);
 
-        if (session == null) {
-            return null;
+        Login login = parameter.getParameterAnnotation(Login.class);
+
+        if (session == null || session.getAttribute(AuthConstant.AUTH_SESSION_KEY) == null) {
+            if (login.allowUnauthenticated()) {
+                return AuthVo.newUnauthenticatedInstance();
+            }
+
+            throw new IllegalAccessException();
         }
 
-        return session.getAttribute(AuthConstant.AUTH_SESSION_KEY);
+        AuthVo authVo = (AuthVo) session.getAttribute(AuthConstant.AUTH_SESSION_KEY);
+
+        if (authVo.isAuthenticated()) {
+            return authVo;
+        }
+
+        throw new IllegalAccessException();
     }
 }

--- a/src/main/java/io/github/teamwaff1e/waffle/global/config/WebConfig.java
+++ b/src/main/java/io/github/teamwaff1e/waffle/global/config/WebConfig.java
@@ -20,12 +20,12 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
 //        registry.addInterceptor(new LoginInterceptor())
 //                .order(1)
-////                .addPathPatterns("/members**") // todo
+//                .addPathPatterns("/**") // todo
 //                .excludePathPatterns(
-//                        "/auth**",
-//                        "/members/{[0-9+]}",
-//                        "/members**"// todo
-//
+//                        "/auth/**",
+//                        "/errors/**",
+//                        "/members",
+//                        "/members/{[0-9]+}"
 //                );
     }
 }

--- a/src/main/java/io/github/teamwaff1e/waffle/global/interceptor/LoginInterceptor.java
+++ b/src/main/java/io/github/teamwaff1e/waffle/global/interceptor/LoginInterceptor.java
@@ -1,10 +1,13 @@
 package io.github.teamwaff1e.waffle.global.interceptor;
 
+import io.github.teamwaff1e.waffle.global.annotation.Login;
 import io.github.teamwaff1e.waffle.global.constant.auth.AuthConstant;
 import io.github.teamwaff1e.waffle.global.error.path.ErrorPath;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import java.util.Arrays;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 public class LoginInterceptor implements HandlerInterceptor {
@@ -13,9 +16,18 @@ public class LoginInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
 
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+
+        Login login = Arrays.stream(handlerMethod.getMethodParameters())
+                .filter(methodParameter -> methodParameter.hasParameterAnnotation(Login.class))
+                .findAny()
+                .orElseThrow(IllegalStateException::new) // todo
+                .getParameterAnnotation(Login.class);
+
         HttpSession session = request.getSession(false);
 
-        if (session == null || session.getAttribute(AuthConstant.AUTH_SESSION_KEY) == null) {
+        if (session == null || session.getAttribute(AuthConstant.AUTH_SESSION_KEY) == null
+                || login.allowUnauthenticated()) {
             request.getRequestDispatcher(ErrorPath.UNAUTHENTICATED).forward(request, response);
             return false;
         }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
Issue 해결 및 버그 수정


## 작업사항
- Issue #22 해결
- 댓글 삭제 시 다른 사람 댓글도 삭제가 가능한 버그 수정


## 변경로직
- `AuthVo`에 static factory method 적용
  1. `AuthVo.from()`
  2. `AuthVo.newUnauthenticatedInstance()`
- `AuthVo`가 두가지 상태를 갖게 변경 (null 문제 해결)
  1. 인증된 멤버 (`authVo.isAuthenticated() == true`)
  2. 인증되지 않은 멤버 (`authVo.isAuthenticated() == false`)
- `@Login` 변경: `@Login(allowUnauthenticated = true)`로 인증되지 않은 멤버가 parameter로 넘어오는 것을 허용
  - 기본적으로는 허용하지 않는다.

## 전달 사항

- `LoginInterceptor`를 적용할 api 정리하기